### PR TITLE
fix test for is_palindrome() function in U1.ipynb

### DIFF
--- a/U1.ipynb
+++ b/U1.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:7bef92dd8cf0144c476dc1ce16da1674287d18e5077b9f6a9bc9d70cbd192663"
+  "signature": "sha256:05d5916309defd073b55bd826fba61e2ec7e3ff63aba6c56e1dab8880e39f73b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -131,7 +131,7 @@
       "\n",
       "print is_palindrome('ala') == True\n",
       "print is_palindrome('ananas') == False\n",
-      "print is_palindrome('ananasa') == True\n",
+      "print is_palindrome('ananasa') == False\n",
       "print is_palindrome('tomek') == False"
      ],
      "language": "python",


### PR DESCRIPTION
Since *ananasa* is not a palindrome, `is_palindrome('ananasa')` should return `False`.