### PR TITLE
use 'in' instead of 'has_key' with dict

### DIFF
--- a/L2.ipynb
+++ b/L2.ipynb
@@ -789,7 +789,7 @@
       "    }\n",
       "    defaults.update(kwargs)\n",
       "    print defaults\n",
-      "    print defaults.has_key('banana')\n",
+      "    print 'banana' in defaults\n",
       "\n",
       "some_function()\n",
       "some_function(apple=10)\n",


### PR DESCRIPTION
According to [python docs](https://docs.python.org/2/library/stdtypes.html#dict.has_key) 'has_key()' is deprecated
