### PR TITLE
Method test is defined after it is being used. Fixed.

### DIFF
--- a/U3.ipynb
+++ b/U3.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:35cb76e3c58f6eb0dce75c896e4a93723535693a26a211aeacb9caa37469c883"
+  "signature": "sha256:290334b2f39f8ecfa4e78f90feee3981d8f58c085c9732501b4f6f99bb92bbee"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -158,14 +158,14 @@
       "def g(x):\n",
       "    return x*x*x+3\n",
       "\n",
+      "def test(a, b, eps=1):\n",
+      "    return abs(round(a)-round(b)) < eps\n",
+      "\n",
       "print(test(f(100), 200.0))\n",
       "print(round(f(0)) == 0.0)\n",
       "\n",
       "print(test(g(100), 30000.0))\n",
       "print(round(g(0)) == 0.0)\n",
-      "\n",
-      "def test(a, b, eps=1):\n",
-      "    return abs(round(a)-round(b)) < eps\n",
       "\n",
       "from random import random\n",
       "for x in [random()*1000. for _ in xrange(20)]:\n",


### PR DESCRIPTION
In task `6`  this error is present:

```
TypeError                                 Traceback (most recent call last)
<ipython-input-20-aeaa5b4c763d> in <module>()
     17     return x*x*x+3
     18 
---> 19 print(test(f(100), 200.0))
     20 print(round(f(0)) == 0.0)
     21 

TypeError: 'float' object is not callable
```

That's because, as the issue follows, method `test` is being used and only then defined. This commit should fix that.